### PR TITLE
Fixed JP translation

### DIFF
--- a/addons/sheet_medevac_nineliner/stringtable.xml
+++ b/addons/sheet_medevac_nineliner/stringtable.xml
@@ -6,7 +6,7 @@
                 <Original>Medevac 9-Liner</Original>
                 <English>Medevac 9-Liner</English>
                 <German>Medevac 9-Liner</German>
-                <Japanese>負傷者救護9ライナー</Japanese>
+                <Japanese>Medevac 9ライナー</Japanese>
             </Key>
         </Container>
         <Container name="Settings">
@@ -14,13 +14,13 @@
                 <Original>Disable MedEvac 9-Liner sheet</Original>
                 <English>Disable MedEvac 9-Liner sheet</English>
                 <German>Medevac 9-Liner Blatt deaktivieren</German>
-                <Japanese>負傷者救護9ライナーシートを無効化する</Japanese>
+                <Japanese>Medevac 9ライナーシートを無効化する</Japanese>
             </Key>
             <Key ID="STR_nln_Settings_keybindOpenNinelinerMedevac">
                 <Original>Open MEDEVAC 9-Liner</Original>
                 <English>Open MEDEVAC 9-Liner</English>
                 <German>MEDEVAC 9-Liner öffnen</German>
-                <Japanese>負傷者救護9ライナーを開く</Japanese>
+                <Japanese>Medevac 9ライナーを開く</Japanese>
             </Key>
         </Container>
     </Package>


### PR DESCRIPTION
Fixed JP  excessive translation of the word "Medevac", from 「負傷者救護」 to "Medevac".
Closer to the original, More legible to JP users.